### PR TITLE
Compiler config cwd pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,25 +38,24 @@ npm i @ton.org/func-js
 ## Usage example
 
 ```typescript
-import {compileFunc, compilerVersion} from 'ton-compiler';
+import {compileFunc, compilerVersion} from '@ton.org/func-js';
 import {Cell} from 'ton';
+import {readFileSync} from "fs";
 
 
 async function main() {
     // You can get compiler version 
     let version = await compilerVersion();
     
-    let result = await funcCompile({
+    let result = await compileFunc({
         // Entry points of your project
-        entryPoints: ['main.fc'],
-        // Sources
+        entryPoints: ["stdlib.fc", "wallet-code.fc"],
         sources: {
-            "stdlib.fc": "<stdlibCode>",
-            "main.fc": "<contractCode>",
-            // Rest of the files which are included in main.fc if some
+            "stdlib.fc": readFileSync('./stdlib.fc', { encoding: 'utf-8' }),
+            "wallet-code.fc":  readFileSync('./wallet-code.fc', { encoding: 'utf-8' })
         }
     });
-
+    
     if (result.status === 'error') {
         console.error(result.message)
         return;
@@ -66,7 +65,7 @@ async function main() {
     let codeCell = Cell.fromBoc(Buffer.from(result.codeBoc, "base64"))[0];
     
     // result.fiftCode contains assembly version of your code (for debug purposes)
-    console.log(result.fiftCode)
+    console.log(codeCell)
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -18,12 +18,15 @@
         "test": "jest",
         "release": "rm -fr dist && jest && yarn build && yarn publish --access public"
     },
-    "dependencies": {},
+    "dependencies": {
+        "glob": "^8.0.3"
+    },
     "devDependencies": {
+        "@types/glob": "^8.0.0",
         "@types/jest": "^24.0.23",
         "jest": "^26.4.2",
+        "ton": "^11.18.2",
         "ts-jest": "^26.4.0",
-        "typescript": "^3.7.2",
-        "ton": "^11.18.2"
+        "typescript": "^3.7.2"
     }
 }

--- a/test/compiler.spec.ts
+++ b/test/compiler.spec.ts
@@ -30,7 +30,7 @@ describe('ton-compiler', () => {
         result = result as SuccessResult;
 
         let codeCell = Cell.fromBoc(Buffer.from(result.codeBoc, "base64"))[0];
-        expect(codeCell.hash().equals(walletCodeCellHash)).toBe(true)
+        expect(codeCell.hash().equals(walletCodeCellHash)).toBe(true);
     });
 
     it('should handle includes', async () => {
@@ -48,49 +48,66 @@ describe('ton-compiler', () => {
         result = result as SuccessResult;
 
         let codeCell = Cell.fromBoc(Buffer.from(result.codeBoc, "base64"))[0];
-        expect(codeCell.hash().equals(walletCodeCellHash)).toBe(true)
+        expect(codeCell.hash().equals(walletCodeCellHash)).toBe(true);
+    });
+
+    it('should handle includes using cwd pattern', async () => {
+        let result = await compileFunc({
+            optLevel: 2,
+            entryPoints: ["wallet-code-with-include.fc"],
+            cwdPattern: "./test/contracts/**/*.fc",
+        });
+
+        expect(result.status).toEqual('ok');
+
+        result = result as SuccessResult;
+
+        let codeCell = Cell.fromBoc(Buffer.from(result.codeBoc, "base64"))[0];
+        expect(codeCell.hash().equals(walletCodeCellHash)).toBe(true);
     });
 
     it('should fail if entry point source is not provided', async () => {
-        expect(compileFunc({
-            optLevel: 2,
-            entryPoints: ["main.fc"],
-            sources: {
-            }
-        })).rejects.toThrowError('The entry point main.fc has not provided in sources.');
+        expect(
+            compileFunc({
+                optLevel: 2,
+                entryPoints: ["main.fc"],
+                sources: {
+                }
+            })
+        ).rejects.toThrowError("The entry point main.fc has not provided in sources.");
     });
 
     it('should handle pragma', async () => {
         let source = `
             #pragma version ^${compilerVersionExpected.funcVersion};
-            
+
             () main() { return(); }
-        `
+        `;
         let result = await compileFunc({
             optLevel: 1,
             entryPoints: ["main.fc"],
             sources: {
                 "main.fc": source,
-            }
+            },
         });
 
-        expect(result.status).toEqual('ok')
+        expect(result.status).toEqual('ok');
 
         source = `
             #pragma version <${compilerVersionExpected.funcVersion};
-            
+
             () main() { return(); }
-        `
+        `;
         result = await compileFunc({
             optLevel: 1,
             entryPoints: ["main.fc"],
             sources: {
                 "main.fc": source,
-            }
+            },
         });
 
-        expect(result.status).toEqual('error')
+        expect(result.status).toEqual('error');
         result = result as ErrorResult;
         expect(result.message.indexOf(`FunC version ${compilerVersionExpected.funcVersion} does not satisfy condition <0.2.0`) != undefined);
-    })
+    });
 });


### PR DESCRIPTION
I added a new flag to **CompilerOptions** using globe pattern 

so instead of declaring each file in the SourceMap format ` "stdlib.fc": fs.readFileSync('./test/contracts/stdlib.fc', { encoding: 'utf-8' }),`
the compilerOptions is recives a glob pattern such `cwdPattern: "./test/contracts/**/*.fc"`

Please checkout the test I have added `should handle includes using cwd pattern`

Thanks